### PR TITLE
Got-002 blood family relationships

### DIFF
--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -42,6 +42,11 @@ class Character < ApplicationRecord
   belongs_to :house, inverse_of: :characters
   has_many :images, as: :imageable, inverse_of: :imageable
 
+  has_many :sons_as_father, class_name: 'Character', foreign_key: 'father_id'
+  has_many :sons_as_mother, class_name: 'Character', foreign_key: 'mother_id'
+  belongs_to :father, class_name: 'Character', optional: true
+  belongs_to :mother, class_name: 'Character', optional: true
+
   validates :name, presence: true, uniqueness: true
   validates :description, presence: true
 
@@ -51,10 +56,15 @@ class Character < ApplicationRecord
       row_hash = row.to_hash
       attributes = get_attributes_from(row_hash)
       new_character = Character.find_or_initialize_by(name: attributes[:name])
+      father_name = attributes.delete(:father)
+      mother_name = attributes.delete(:mother)
       new_character.assign_attributes(attributes)
       if (imported = new_character.save)
         new_character.images.build
         new_character.images = get_images_from(row_hash)
+        new_character.father_name = father_name
+        new_character.mother_name = mother_name
+        new_character.establish_parenthood_association
       end
 
       {
@@ -112,5 +122,68 @@ class Character < ApplicationRecord
       end
       images
     end
+
+    def establish_parenthood_association_for_all_characters
+      results = []
+      Character.all.map do |son|
+        %w[father mother].each do |parent_role|
+          results.push son.search_and_save_parent_with_diagnosis(parent_role)
+        end
+      end
+      results
+    end
+  end
+
+  def search_and_save_parent_with_diagnosis(parent_role)
+    son = self
+    son_parent_name = son.send(parent_role + '_name')
+    if son_parent_name &&
+       (parent_character = Character.find_by(name: son_parent_name))
+      son.update("#{parent_role}_id": parent_character.id)
+      diagnosis = "##{son['id']}: found character #{parent_role}"
+    elsif (possible_parents = Character.where('children like ?',
+                                              "%#{son.name}%"))
+      diagnosis = "##{son['id']}: #{son.name} parent found indirectly: _
+        #{possible_parents.map(&:name).join(', ')}. _
+        Change or enter current #{parent_role} name in son's record and _
+        rerun this task."
+    elsif !son_parent_name.present?
+      diagnosis = "##{son['id']}: has no #{parent_role} name and not found _
+        in children fields"
+    else
+      diagnosis = "Parent character named #{son[parent_role]} not found for _
+        son #{son['name']}. Check the name spelling. _
+        Change #{parent_role} name in son's record and rerun this task."
+    end
+    { id: son.id, son: son, diagnosis: diagnosis }
+  end
+
+  def establish_parenthood_association
+    %w[father mother].each do |parent_role|
+      parent_name = self.send(parent_role + '_name')
+      if (parent_character = Character.find_by(name: parent_name))
+        self.update("#{parent_role}_id": parent_character.id)
+      end
+    end
+  end
+
+  def mother_name
+    mother.try(:name) || self[:mother]
+  end
+
+  def father_name
+    father.try(:name) || self[:father]
+  end
+
+  def mother_name=(name)
+    self[:mother] = name
+  end
+
+  def father_name=(name)
+    self[:father] = name
+  end
+
+  def children_names
+    (sons_as_father + sons_as_mother).map(&:name) || self[:children]
   end
 end

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -184,6 +184,6 @@ class Character < ApplicationRecord
   end
 
   def children_names
-    (sons_as_father + sons_as_mother).map(&:name) || self[:children]
+    (sons_as_father + sons_as_mother).map(&:name)
   end
 end

--- a/db/migrate/20180613060925_add_blood_relationships_to_character.rb
+++ b/db/migrate/20180613060925_add_blood_relationships_to_character.rb
@@ -1,0 +1,6 @@
+class AddBloodRelationshipsToCharacter < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :characters, :father, index: true
+    add_reference :characters, :mother, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170112162805) do
+ActiveRecord::Schema.define(version: 20180613060925) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,7 +47,11 @@ ActiveRecord::Schema.define(version: 20170112162805) do
     t.boolean  "appears_in_season_9"
     t.datetime "created_at",          null: false
     t.datetime "updated_at",          null: false
+    t.integer  "father_id"
+    t.integer  "mother_id"
+    t.index ["father_id"], name: "index_characters_on_father_id", using: :btree
     t.index ["house_id"], name: "index_characters_on_house_id", using: :btree
+    t.index ["mother_id"], name: "index_characters_on_mother_id", using: :btree
   end
 
   create_table "houses", force: :cascade do |t|

--- a/lib/tasks/character_tasks.rake
+++ b/lib/tasks/character_tasks.rake
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+namespace :character do
+  desc 'Assign Father and Mother characters from names in correspondant fields'
+  task establish_parenthood_association: :environment do
+    puts 'Working...!'
+    results = Character.establish_parenthood_association_for_all_characters
+    puts 'Done! Printing results'
+    puts results
+  end
+end

--- a/spec/factories/characters.rb
+++ b/spec/factories/characters.rb
@@ -51,8 +51,8 @@ FactoryGirl.define do
     religion { Faker::Lorem.sentence }
     predecessor { Faker::GameOfThrones.character }
     successor { Faker::GameOfThrones.character }
-    father { Faker::GameOfThrones.character }
-    mother { Faker::GameOfThrones.character }
+    father_name { Faker::GameOfThrones.character }
+    mother_name { Faker::GameOfThrones.character }
     spouse { Faker::GameOfThrones.character }
     children { Faker::GameOfThrones.character }
     siblings { Faker::GameOfThrones.character }


### PR DESCRIPTION
Initial information:
Add relationships between characters
I think our editors make mistakes we could avoid. I.e.: Robb Stark's father was Eddard Stark, but they forgot to add Robb as son of Eddard.
So I think is better to only define the relation in one direction with each character's father and mother. This way we avoid keystrokes and remove unnecessary and redundant fields like children.
Spouse and in-laws can be a little bit more difficult, as there are characters with more than one, so for the moment we won't do it. I prefer experimenting this new solution for blood family relationships and if it works properly, maybe we'll do for in-laws as well.
